### PR TITLE
Don't assume 'schemes' is defined

### DIFF
--- a/src/utils/normalize/swagger.js
+++ b/src/utils/normalize/swagger.js
@@ -53,7 +53,7 @@ export const normalizeSwagger2p0 = data => {
     });
   });
 
-  const scheme = data.schemes.includes('https') ? 'https' : 'http';
+    const scheme = (data.schemes != undefined && data.schemes.includes('https')) ? 'https' : 'http';
   if (!data.basePath) {
     data.basePath = base
   }


### PR DESCRIPTION
flask-restx does not provide the schemes property as part of its schema.  And swagger 2.0 says this is optional.  While the scheme should then default to whatever method was used to request the schema, I don't know how to determine that so I figured http was a good default. 